### PR TITLE
Normalizing by decimal delta between asset and vault

### DIFF
--- a/src/WrappedVault.sol
+++ b/src/WrappedVault.sol
@@ -140,7 +140,9 @@ contract WrappedVault is Owned, ERC20, IWrappedVault {
         DEPOSIT_ASSET = ERC20(VAULT.asset());
         POINTS_FACTORY = PointsFactory(pointsFactory);
 
-        uint256 decimalOffset = ERC20(vault).decimals() > DEPOSIT_ASSET.decimals() ? ERC20(vault).decimals() - DEPOSIT_ASSET.decimals() : 0;
+        uint256 vaultDecimals = ERC20(vault).decimals();
+        uint256 assetDecimals = DEPOSIT_ASSET.decimals();
+        uint256 decimalOffset = vaultDecimals > assetDecimals ? vaultDecimals - assetDecimals : 0;
         DECIMAL_NORMALIZATION_FACTOR = 10 ** decimalOffset;
 
         _mint(address(0), 10_000); // Burn 10,000 wei to stop 'first share' front running attacks on depositors


### PR DESCRIPTION
Not as elegant as normalizing by assets, but hopefully safer.

If the vault has a higher decimal count that its asset, we use the difference as a scalar to:
1. Normalize the rate up when accumulating rewards per token
2. Rewards down when accumulating rewards per user.

I haven't included the tweak to only pull rewards that are expected to be distributed.

Normalizing the rate up shouldn't overflow, because we upcast from u96 to u256.

There would be some rounding down of user rewards when accumulating them, I do not know the actual impact.